### PR TITLE
release: v0.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 on: push
-name: Build extel
+name: Build Extel
 jobs:
   build_extel:
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,7 +1,7 @@
 on: push
 name: Clippy Check
 jobs:
-  clippy_check:
+  extel:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -15,13 +15,20 @@ jobs:
           components: clippy
 
       - name: Check extel
-        uses: actions-rs/clippy-check@v1
+        run: cargo clippy --all-features --manifest-path ./extel/Cargo.toml -- -Dwarnings
+
+  extel_parameterized:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --manifest-path ./extel/Cargo.toml
+          toolchain: stable
+          default: true
+          components: clippy
 
       - name: Check extel_parameterized
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --manifest-path ./extel_parameterized/Cargo.toml
+        run: cargo clippy --all-features --manifest-path ./extel_parameterized/Cargo.toml -- -Dwarnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All changes to Extel should be logged here after the release is generated and ex
 ### Documentation
   - Update some docs to include features introduced in v0.1.3 and new features introduced in v0.2.0.
 
+### CI
+  - Remove clippy action and instead run clippy manually in a shell through an action.
+
 ## v0.1.3
 ### Fixes
   - Fixed extel_assert missing from extel::prelude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Extel Changelog
 All changes to Extel should be logged here after the release is generated and extel is published to cargo.
 
+## v0.2.0
+### Features
+  - cmd! macro now supports Path/PathBuf/OsStr using the cmd!(CMD => [arg1, arg2, ...]) syntax.
+  - err! macro maps strings to a TestFailed error.
+  - ExtelResult is now a Result<(), extel::errors::Error> type to support error propagation.
+
+### Fixes
+  - extel_parameterized no longer throws errors when the function the macro is affecting as a doc comment.
+
+### Documentation
+  - Update some docs to include features introduced in v0.1.3 and new features introduced in v0.2.0.
+
 ## v0.1.3
 ### Fixes
   - Fixed extel_assert missing from extel::prelude

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Extel - Extendable Testing Library
+# Extel - Extended Testing Library
 Extel is a testing library for Rust that supports both unit/integration testing for Rust projects and external APIs
-through FFI/`std::process`.
+through FFI or std::process.
 
 # Using Extel
 Extel is designed to work with *stateless functions*. Originally built to test executables built in C, Extel follows the
@@ -38,16 +38,24 @@ wrap the input in a tuple or struct to test. You must add Extel with the `parame
 /// Check if the number is positive.
 #[parameters(5, 10, -1)]
 fn positive_num(n: usize) -> ExtelResult {
-    if n > 0 {
-        pass!()
-    } else {
-        fail!("{} is not positive", n)
-    }
+    extel_assert!(n > 0, "{} is not positive", n)
 }
 
+/// # TEST
+/// Passing multiple args, check if lhs is greater than rhs.
+#[parameters((4, 3), (4, 6))]
+fn greater_than(nums: (usize, usize)) -> ExtelResult {
+    let (lhs, rhs) = nums;
+    extel_assert!(
+        lhs > rhs,
+        "left hand side is less than or equal to right hand side! ({} <= {})",
+        lhs,
+        rhs
+    )
+}
 
 fn main() {
-    init_test_suite!(ParameterizedTestSet, positive_num);
+    init_test_suite!(ParameterizedTestSet, positive_num, greater_than);
     ParameterizedTestSet::run(TestConfig::default().output(OutputStyle::Stdout));
 }
 ```

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 extel = { path = "../extel", features = ["parameterized"] }
+thiserror = "1.0.49"

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -1,12 +1,19 @@
 pub mod tests;
 
 use extel::prelude::*;
-use tests::{command_tests::*, math_tests::*};
+use tests::{command_tests::*, math_tests::*, utf8_tests::*};
 
 fn main() {
     init_test_suite!(MathTestSuite, calculate, perfect_sqrt);
     init_test_suite!(CommandTestSuite, echo, c_exe);
+    init_test_suite!(
+        Utf8TestSuite,
+        good_utf8,
+        bad_utf8,
+        original_handle_crash_way
+    );
 
     MathTestSuite::run(TestConfig::default());
     CommandTestSuite::run(TestConfig::default());
+    Utf8TestSuite::run(TestConfig::default());
 }

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -1,19 +1,19 @@
 pub mod tests;
 
 use extel::prelude::*;
-use tests::{command_tests::*, math_tests::*, utf8_tests::*};
+use tests::{
+    command_tests::CommandTestSuite, math_tests::MathTestSuite,
+    unsupported_errors::UnsupportedErrorTestSuite, utf8_tests::Utf8TestSuite,
+};
 
 fn main() {
-    init_test_suite!(MathTestSuite, calculate, perfect_sqrt);
-    init_test_suite!(CommandTestSuite, echo, c_exe);
-    init_test_suite!(
-        Utf8TestSuite,
-        good_utf8,
-        bad_utf8,
-        original_handle_crash_way
-    );
+    run_tests::<MathTestSuite>();
+    run_tests::<CommandTestSuite>();
+    run_tests::<Utf8TestSuite>();
+    run_tests::<UnsupportedErrorTestSuite>();
+}
 
-    MathTestSuite::run(TestConfig::default());
-    CommandTestSuite::run(TestConfig::default());
-    Utf8TestSuite::run(TestConfig::default());
+/// Run test set with default configuration.
+fn run_tests<S: RunnableTestSet>() {
+    S::run(TestConfig::default());
 }

--- a/e2e/src/tests/command_tests.rs
+++ b/e2e/src/tests/command_tests.rs
@@ -1,6 +1,6 @@
 use std::process::Stdio;
 
-use extel::{cmd, fail, parameters, pass, ExtelResult};
+use extel::prelude::*;
 
 #[parameters("hello world", "viva las vegas", "extel's working!")]
 pub(crate) fn echo(x: &str) -> ExtelResult {
@@ -9,11 +9,12 @@ pub(crate) fn echo(x: &str) -> ExtelResult {
     let string_output = String::from_utf8_lossy(&output.stdout);
 
     // Verify echo works correctly.
-    if string_output == x {
-        pass!()
-    } else {
-        fail!("expected '{}', got '{}'", x, string_output)
-    }
+    extel_assert!(
+        string_output == x,
+        "expected '{}', got '{}'",
+        x,
+        string_output
+    )
 }
 
 #[parameters(vec![], vec![1], vec![1, 2])]
@@ -32,10 +33,7 @@ pub(crate) fn c_exe(x: Vec<usize>) -> ExtelResult {
 
     // Verify that no errors occur
     if let Some(code) = status.code() {
-        match code {
-            0 => pass!(),
-            _ => fail!("returned exit code: {}", code),
-        }
+        extel_assert!(code == 0, "returned exit code: {}", code)
     } else {
         fail!("could not extract exit code")
     }

--- a/e2e/src/tests/command_tests.rs
+++ b/e2e/src/tests/command_tests.rs
@@ -5,8 +5,8 @@ use extel::prelude::*;
 #[parameters("hello world", "viva las vegas", "extel's working!")]
 pub(crate) fn echo(x: &str) -> ExtelResult {
     let mut echo_cmd = cmd!("echo -n \"{}\"", x);
-    let output = echo_cmd.output().unwrap();
-    let string_output = String::from_utf8_lossy(&output.stdout);
+    let output = echo_cmd.output()?;
+    let string_output = String::from_utf8(output.stdout)?;
 
     // Verify echo works correctly.
     extel_assert!(
@@ -29,12 +29,11 @@ pub(crate) fn c_exe(x: Vec<usize>) -> ExtelResult {
     };
 
     let mut c_cmd = cmd!("./bin/test {}", args);
-    let status = c_cmd.stdout(Stdio::null()).status().unwrap();
+    let status = c_cmd.stdout(Stdio::null()).status()?;
 
     // Verify that no errors occur
-    if let Some(code) = status.code() {
-        extel_assert!(code == 0, "returned exit code: {}", code)
-    } else {
-        fail!("could not extract exit code")
-    }
+    let code = status.code().ok_or(err!("could not extract exit code"))?;
+    extel_assert!(code == 0, "returned exit code: {}", code)
 }
+
+init_test_suite!(CommandTestSuite, echo, c_exe);

--- a/e2e/src/tests/math_tests.rs
+++ b/e2e/src/tests/math_tests.rs
@@ -1,13 +1,9 @@
-use extel::{fail, parameters, pass, ExtelResult};
+use extel::prelude::*;
 
 #[parameters(4_f64, 16_f64, 30_f64, 32_f64)]
 pub fn perfect_sqrt(x: f64) -> ExtelResult {
     let sqrt = x.sqrt();
-    if sqrt == sqrt.floor() {
-        pass!()
-    } else {
-        fail!("{} is not a perfect square", x)
-    }
+    extel_assert!(sqrt == sqrt.floor(), "{} is not a perfect square", x)
 }
 
 fn __calculate(x: f64, y: f64) -> f64 {
@@ -16,9 +12,9 @@ fn __calculate(x: f64, y: f64) -> f64 {
 
 pub fn calculate() -> ExtelResult {
     let result = __calculate(10_f64, 2_f64);
-    if result > 0_f64 {
-        pass!()
-    } else {
-        fail!("value of __calculate(10, 2) <= 0: got {}", result)
-    }
+    extel_assert!(
+        result > 0_f64,
+        "value of __calculate(10, 2) <= 0: got {}",
+        result
+    )
 }

--- a/e2e/src/tests/math_tests.rs
+++ b/e2e/src/tests/math_tests.rs
@@ -18,3 +18,5 @@ pub fn calculate() -> ExtelResult {
         result
     )
 }
+
+init_test_suite!(MathTestSuite, calculate, perfect_sqrt);

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod command_tests;
 pub mod math_tests;
+pub mod unsupported_errors;
 pub mod utf8_tests;

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -1,2 +1,3 @@
 pub mod command_tests;
 pub mod math_tests;
+pub mod utf8_tests;

--- a/e2e/src/tests/unsupported_errors.rs
+++ b/e2e/src/tests/unsupported_errors.rs
@@ -1,0 +1,22 @@
+use extel::prelude::*;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum UnsupportedError {
+    #[allow(dead_code)]
+    #[error("this is an error")]
+    MyErrorVariant,
+}
+
+fn unsupported_error() -> ExtelResult {
+    let foo = || -> Result<usize, UnsupportedError> { Ok(0) };
+
+    // This would not compile!
+    // let res = foo()?;
+
+    // This will compile!
+    let res = foo().map_err(|e| err!("{}", e))?;
+    extel_assert!(res == 0)
+}
+
+init_test_suite!(UnsupportedErrorTestSuite, unsupported_error);

--- a/e2e/src/tests/utf8_tests.rs
+++ b/e2e/src/tests/utf8_tests.rs
@@ -8,15 +8,21 @@ pub(crate) fn good_utf8() -> ExtelResult {
 
 pub(crate) fn bad_utf8() -> ExtelResult {
     let utf8 = *b"\xFF";
-    let _ = std::fs::File::open("./asodfijasdoifasd")?;
     let _ = String::from_utf8(utf8.into())?;
     pass!()
 }
 
 pub(crate) fn original_handle_crash_way() -> ExtelResult {
     let utf8 = *b"\xFF";
-    if let Err(_) = String::from_utf8(utf8.into()) {
+    if String::from_utf8(utf8.into()).is_err() {
         return fail!("invalid conversion from UTF-8");
     }
     pass!()
 }
+
+init_test_suite!(
+    Utf8TestSuite,
+    good_utf8,
+    bad_utf8,
+    original_handle_crash_way
+);

--- a/e2e/src/tests/utf8_tests.rs
+++ b/e2e/src/tests/utf8_tests.rs
@@ -1,0 +1,22 @@
+use extel::prelude::*;
+
+pub(crate) fn good_utf8() -> ExtelResult {
+    let utf8 = *b"\x00";
+    let _ = String::from_utf8(utf8.into())?;
+    pass!()
+}
+
+pub(crate) fn bad_utf8() -> ExtelResult {
+    let utf8 = *b"\xFF";
+    let _ = std::fs::File::open("./asodfijasdoifasd")?;
+    let _ = String::from_utf8(utf8.into())?;
+    pass!()
+}
+
+pub(crate) fn original_handle_crash_way() -> ExtelResult {
+    let utf8 = *b"\xFF";
+    if let Err(_) = String::from_utf8(utf8.into()) {
+        return fail!("invalid conversion from UTF-8");
+    }
+    pass!()
+}

--- a/extel/Cargo.toml
+++ b/extel/Cargo.toml
@@ -16,5 +16,5 @@ features = ["parameterized"]
 parameterized = []
 
 [dependencies]
-extel_parameterized = { path = "../extel_parameterized" }
+extel_parameterized = "0.1.1"
 thiserror = "1.0.49"

--- a/extel/Cargo.toml
+++ b/extel/Cargo.toml
@@ -16,4 +16,5 @@ features = ["parameterized"]
 parameterized = []
 
 [dependencies]
-extel_parameterized = "0.1.0"
+extel_parameterized = { path = "../extel_parameterized" }
+thiserror = "1.0.49"

--- a/extel/Cargo.toml
+++ b/extel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "extel"
 description = "An extended testing library for scaffolding tests as quickly and easily as possible"
 authors = ["Jacob Strader <jtstrader851@gmail.com>"]
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/jtstrader/extel"
 license = "MIT"

--- a/extel/README.md
+++ b/extel/README.md
@@ -23,7 +23,7 @@ will cause the macros generating the test suite to fail, or will return some wei
 using the `parameters` proc macro.
 
 ```rust
-use extel::{pass, fail, cmd, init_test_suite, ExtelResult, RunnableTestSet, TestConfig};
+use extel::prelude::*;
 use extel_parameterized::parameters;
 
 fn single_test() -> ExtelResult {
@@ -31,20 +31,16 @@ fn single_test() -> ExtelResult {
     let output = my_cmd.output().unwrap();
     let string_output = String::from_utf8_lossy(&output.stdout);
 
-    if string_output == *"hello world" {
-        pass!()
-    } else {
-        fail!("expected 'hello world', got '{}'", string_output)
-    }
+    extel_assert!(
+        string_output == *"hello world",
+        "expected 'hello world', got '{}'",
+        string_output
+    )
 }
 
 #[parameters(1, 2, -2, 4)]
 fn param_test(x: i32) -> ExtelResult {
-    if x >= 0 {
-        pass!()
-    } else {
-        fail!("{} < 0", x)
-    }
+    extel_assert!(x >= 0, "{} < 0", x)
 }
 
 fn main() {

--- a/extel/README.md
+++ b/extel/README.md
@@ -28,8 +28,8 @@ use extel_parameterized::parameters;
 
 fn single_test() -> ExtelResult {
     let mut my_cmd = cmd!("echo -n \"hello world\"");
-    let output = my_cmd.output().unwrap();
-    let string_output = String::from_utf8_lossy(&output.stdout);
+    let output = my_cmd.output()?;
+    let string_output = String::from_utf8(output.stdout)?;
 
     extel_assert!(
         string_output == *"hello world",
@@ -47,3 +47,17 @@ fn main() {
     init_test_suite!(ExtelDemo, single_test, param_test);
     ExtelDemo::run(TestConfig::default());
 }
+```
+
+Extel supports error propagation through `?`. If the `From` trait for your custom error is not
+supported, you can use the `err!` macro to help map errors to a generic `TestFailed` variant.
+
+```rs
+fn cool_err_handling() -> ExtelResult {
+    let invalid_utf8 = *b"\xE0\x80\x80";
+    let utf8_check = String::from_utf8(invalid_utf8.into())?;
+    let io_check = std::fs::File::open("./file_not_found.txt")?;
+    let your_custom_err = get_custom_result().map_err(|e| err!("{}", e))?;
+    pass!()
+}
+```

--- a/extel/src/errors.rs
+++ b/extel/src/errors.rs
@@ -1,0 +1,35 @@
+//! Extel errors built using `thiserror`.
+
+use std::{io, string::FromUtf8Error};
+use thiserror::Error;
+
+/// An Extel error type. Allows error propagation with [`ExtelResult`](crate::ExtelResult). Note
+/// that this propagation does not panic the test runner but instead adjusts the test output to
+/// reflect the error that is received.
+///
+/// # Example
+/// ```rust
+/// use std::fs;
+/// use extel::prelude::*;
+///
+/// fn bad_file() -> ExtelResult {
+///     let f = fs::File::open("./this_is_a_bad_file.txt")?;
+///     pass!()
+/// }
+///
+/// fn bad_test() -> ExtelResult {
+///     extel_assert!(2 < 0, "test failed")
+/// }
+///
+/// assert!(matches!(bad_file(), Err(Error::Io(_))));
+/// assert!(matches!(bad_test(), Err(Error::TestFailed(_))));
+/// ```
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("{0}")]
+    TestFailed(String),
+    #[error("an I/O error occurred")]
+    Io(#[from] io::Error),
+    #[error("invalid conversion from UTF-8 ocurred")]
+    FromUtf8(#[from] FromUtf8Error),
+}

--- a/extel/src/lib.rs
+++ b/extel/src/lib.rs
@@ -144,13 +144,10 @@ pub mod macros;
 ///     pass!()
 /// }
 ///
-/// assert_eq!(
-///     vec![true, false, false],
-///     vec![
-///         always_succeed().is_ok(),
-///         always_fail().is_ok(),
-///         early_fail_from_err().is_ok()
-///     ]
+/// assert!(
+///     always_succeed().is_ok() &&
+///     always_fail().is_err() &&
+///     early_fail_from_err().is_err()
 /// );
 /// ```
 pub type ExtelResult = Result<(), Error>;
@@ -285,9 +282,7 @@ pub fn output_test_result<T: Write>(
             ),
             Err(err_msg) => format!(
                 "\tTest #{} ({}) ... {fail_color}FAILED{color_terminator}\n\t  [x] {}\n",
-                test_num,
-                result.test_name,
-                err_msg
+                test_num, result.test_name, err_msg
             ),
         },
         TestStatus::Parameterized(statuses) => statuses

--- a/extel/src/lib.rs
+++ b/extel/src/lib.rs
@@ -80,7 +80,7 @@ pub use extel_parameterized::parameters;
 
 pub mod prelude {
     pub use crate::{
-        cmd, errors::Error, extel_assert, fail, init_test_suite, pass, ExtelResult,
+        cmd, err, errors::Error, extel_assert, fail, init_test_suite, pass, ExtelResult,
         RunnableTestSet, TestConfig,
     };
 
@@ -278,7 +278,7 @@ pub fn output_test_result<T: Write>(
     };
 
     let fmt_output = match &result.test_result {
-        TestStatus::Single(status) => match &*status {
+        TestStatus::Single(status) => match status {
             Ok(()) => format!(
                 "\tTest #{} ({}) ... {ok_color}ok{color_terminator}\n",
                 test_num, result.test_name
@@ -287,7 +287,7 @@ pub fn output_test_result<T: Write>(
                 "\tTest #{} ({}) ... {fail_color}FAILED{color_terminator}\n\t  [x] {}\n",
                 test_num,
                 result.test_name,
-                err_msg.to_string()
+                err_msg
             ),
         },
         TestStatus::Parameterized(statuses) => statuses
@@ -305,7 +305,7 @@ pub fn output_test_result<T: Write>(
                     test_num,
                     idx + 1,
                     result.test_name,
-                    err_msg.to_string()
+                    err_msg
                 ),
             })
             .collect::<String>(),

--- a/extel/src/lib.rs
+++ b/extel/src/lib.rs
@@ -23,7 +23,7 @@
 //! using the `parameters` proc macro.
 //!
 //! ```rust
-//! use extel::{pass, fail, cmd, init_test_suite, ExtelResult, RunnableTestSet, TestConfig};
+//! use extel::prelude::*;
 //! use extel_parameterized::parameters;
 //!
 //! fn single_test() -> ExtelResult {
@@ -31,20 +31,16 @@
 //!     let output = my_cmd.output().unwrap();
 //!     let string_output = String::from_utf8_lossy(&output.stdout);
 //!
-//!     if string_output == *"hello world" {
-//!         pass!()
-//!     } else {
-//!         fail!("expected 'hello world', got '{}'", string_output)
-//!     }
+//!     extel_assert!(
+//!         string_output == *"hello world",
+//!         "expected 'hello world', got '{}'",
+//!         string_output
+//!     )
 //! }
 //!
 //! #[parameters(1, 2, -2, 4)]
 //! fn param_test(x: i32) -> ExtelResult {
-//!     if x >= 0 {
-//!         pass!()
-//!     } else {
-//!         fail!("{} < 0", x)
-//!     }
+//!     extel_assert!(x >= 0, "{} < 0", x)
 //! }
 //!
 //! fn main() {
@@ -62,15 +58,12 @@
 ///
 /// # Example
 /// ```rust
-/// use extel::{fail, pass, ExtelResult, TestResultType, TestStatus};
+/// use extel::prelude::*;
 /// use extel_parameterized::parameters;
 ///
 /// #[parameters(2, 4)]
 /// fn less_than_3(x: i32) -> ExtelResult {
-///     match x < 3 {
-///         true => pass!(),
-///         false => fail!("{} >= 3", x),
-///     }
+///     extel_assert!(x < 3, "{} >= 3", x)
 /// }
 ///
 /// assert_eq!(
@@ -100,15 +93,12 @@ pub mod prelude {
     ///
     /// # Example
     /// ```rust
-    /// use extel::{fail, pass, ExtelResult, TestResultType, TestStatus};
+    /// use extel::prelude::*;
     /// use extel_parameterized::parameters;
     ///
     /// #[parameters(2, 4)]
     /// fn less_than_3(x: i32) -> ExtelResult {
-    ///     match x < 3 {
-    ///         true => pass!(),
-    ///         false => fail!("{} >= 3", x),
-    ///     }
+    ///     extel_assert!(x < 3, "{} >= 3", x)
     /// }
     ///
     /// assert_eq!(

--- a/extel/src/macros.rs
+++ b/extel/src/macros.rs
@@ -70,13 +70,13 @@ macro_rules! fail {
 /// else call the [`fail`] macro.
 ///
 /// The fail macro can contain the following messages depending on which arm of the macro is used:
-///   1. A default message such as "[condition] assertion failed."
+///   1. A default message such as "\[condition\] assertion failed."
 ///   2. A custom error message.
 ///   3. A custom format message that can take variable arguments.
 ///
 /// This assertion is *not* like Rust's [`assert`] macro, and should not panic unless the given
 /// condition or format arguments can panic. This macro returns an
-/// [`ExtelResult`](crate::ExtelResult)
+/// [`ExtelResult`](crate::ExtelResult).
 ///
 /// # Example
 /// ```rust

--- a/extel/src/macros.rs
+++ b/extel/src/macros.rs
@@ -78,6 +78,17 @@ macro_rules! fail {
 /// # Example
 /// ```rust
 /// use extel::{prelude::*, err};
+/// use thiserror::Error;
+///
+/// #[derive(Error, Debug)]
+/// enum MyCustomError {
+///     #[error("{0}")]
+///     CriticalError(String)
+/// }
+///
+/// fn blow_up() -> Result<(), MyCustomError> {
+///     Err(MyCustomError::CriticalError("UH OH!".into()))
+/// }
 ///
 /// const EXPECTED: &str = "Hello, world!";
 ///
@@ -85,10 +96,11 @@ macro_rules! fail {
 ///     let output = cmd!("echo -n \"{}\"", EXPECTED).output()?;
 ///     let output_string = String::from_utf8(output.stdout)?;
 ///     let code = output.status.code().ok_or(err!("could not extract code"))?;
+///     let err = blow_up().map_err(|e| err!("{}", e))?;
 ///     extel_assert!(output_string == *EXPECTED && code == 0)
 /// }
 ///
-/// assert!(my_test().is_ok())
+/// assert!(my_test().is_err())
 /// ```
 #[macro_export]
 macro_rules! err {

--- a/extel/src/macros.rs
+++ b/extel/src/macros.rs
@@ -63,7 +63,7 @@ macro_rules! fail {
         Box::new($crate::TestStatus::Fail(format!($fmt, $($arg),*)))
     };
 
-    ($fmt:expr) => { Box::new($crate::TestStatus::Fail(format!($fmt)))}
+    ($fmt:expr) => { Box::new($crate::TestStatus::Fail(format!($fmt))) }
 }
 
 /// Assert if a given condition is true/false. If the condition is true, call the [`pass`] macro,
@@ -201,18 +201,14 @@ macro_rules! cmd {
 /// # Example
 /// ```rust
 /// use std::process::Command;
-/// use extel::{fail, init_test_suite, pass, ExtelResult, TestConfig, RunnableTestSet};
+/// use extel::prelude::*; 
 ///
 /// /// Run end-to-end test of application.
 /// fn echo_no_arg_e2e() -> ExtelResult {
 ///     match Command::new("echo").status() {
 ///         Ok(exit_code) => {
 ///             let code: i32 = exit_code.code().unwrap_or(-1);
-///             if code == 0 {
-///                 pass!()
-///             } else {
-///                 fail!("failed with exit code {}", code)
-///             }
+///             extel_assert!(code == 0, "failed with exit code: {}", code)
 ///         },
 ///         Err(msg) => {
 ///             fail!("failed to execute with error: {}", msg)
@@ -221,7 +217,7 @@ macro_rules! cmd {
 /// }
 ///
 /// // Outputs:
-/// //  Test #1 (echo_no_arg_e2e): OK
+/// //  Test #1 (echo_no_arg_e2e) ... ok
 /// init_test_suite!(EchoTestSuite, echo_no_arg_e2e);
 /// EchoTestSuite::run(TestConfig::default());
 /// ```
@@ -321,6 +317,9 @@ mod tests {
             let string_output =
                 String::from_utf8(output.stdout).expect("output contained non-UTF-8 chars");
 
+            // LEAVE AS pass!()/fail!() SYNTAX!
+            // There is a test in this module that covers using extel_assert!. Keep these tests to
+            // verify that pass!()/fail!() still functions as expected.
             if string_output == *"hello world" {
                 pass!()
             } else {
@@ -357,6 +356,9 @@ mod tests {
             let string_output =
                 String::from_utf8(output.stdout).expect("output contained non-UTF-8 chars");
 
+            // LEAVE AS pass!()/fail!() SYNTAX!
+            // There is a test in this module that covers using extel_assert!. Keep these tests to
+            // verify that pass!()/fail!() still functions as expected.
             if string_output == *EXPECTED {
                 pass!()
             } else {

--- a/extel_parameterized/Cargo.toml
+++ b/extel_parameterized/Cargo.toml
@@ -2,7 +2,7 @@
 name = "extel_parameterized"
 description = "A proc macro crate for creating parameterized tests for Extel"
 authors = ["Jacob Strader <jtstrader851@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/jtstrader/extel"
 license = "MIT"

--- a/extel_parameterized/README.md
+++ b/extel_parameterized/README.md
@@ -4,7 +4,7 @@ Extel Parameterized, or just *parameterized*, is a proc macro crate that serves 
 `Extel` can interpret.
 
 ```rust
-use extel::{pass, fail, cmd, init_test_suite, ExtelResult, RunnableTestSet, TestConfig};
+use extel::prelude::*;
 use extel_parameterized::parameters;
 
 fn single_test() -> ExtelResult {
@@ -12,20 +12,16 @@ fn single_test() -> ExtelResult {
     let output = my_cmd.output().unwrap();
     let string_output = String::from_utf8_lossy(&output.stdout);
 
-    if string_output == *"hello world" {
-        pass!()
-    } else {
-        fail!("expected 'hello world', got '{}'", string_output)
-    }
+    extel_assert!(
+        string_output == *"hello world",
+        "expected 'hello world', got '{}'"
+        string_output
+    )
 }
 
 #[parameters(1, 2, -2, 4)]
 fn param_test(x: i32) -> ExtelResult {
-    if x >= 0 {
-        pass!()
-    } else {
-        fail!("{} < 0", x)
-    }
+    extel_assert!(x > 0, "{} <= 0", x)
 }
 
 fn main() {

--- a/extel_parameterized/README.md
+++ b/extel_parameterized/README.md
@@ -9,8 +9,8 @@ use extel_parameterized::parameters;
 
 fn single_test() -> ExtelResult {
     let mut my_cmd = cmd!("echo -n \"hello world\"");
-    let output = my_cmd.output().unwrap();
-    let string_output = String::from_utf8_lossy(&output.stdout);
+    let output = my_cmd.output()?;
+    let string_output = String::from_utf8(output.stdout)?;
 
     extel_assert!(
         string_output == *"hello world",

--- a/extel_parameterized/src/lib.rs
+++ b/extel_parameterized/src/lib.rs
@@ -54,20 +54,15 @@ pub fn parameters(attr: TokenStream, function: TokenStream) -> TokenStream {
 
     // Build test runner
     let test_runner_tokens = format!(
-        "let extel_single_results = [{attr_list}].into_iter().map({inner_func_name}).collect::<Vec<extel::ExtelResult>>();\
-        Box::new(
-            extel_single_results
-                .into_iter()
-                .map(TryInto::<extel::TestStatus>::try_into)
-                .flatten()
-                .collect::<Vec<_>>(),
-        )"
-
+        "[{attr_list}]
+            .into_iter()
+            .map({inner_func_name})
+            .collect::<Vec<extel::ExtelResult>>()"
     );
 
     // Create wrapper around the input stream
     let final_func = format!(
-        "{} {}() -> ExtelResult {{ {} {} }}",
+        "{} {}() -> Vec<ExtelResult> {{ {} {} }}",
         tokens[0..func_name_idx]
             .iter()
             .map(|token| token.to_string())

--- a/extel_parameterized/src/lib.rs
+++ b/extel_parameterized/src/lib.rs
@@ -4,7 +4,7 @@
 //! `Extel` can interpret.
 //!
 //! ```rust
-//! use extel::{pass, fail, cmd, init_test_suite, ExtelResult, RunnableTestSet, TestConfig};
+//! use extel::prelude::*;
 //! use extel_parameterized::parameters;
 //!
 //! fn single_test() -> ExtelResult {
@@ -12,20 +12,16 @@
 //!     let output = my_cmd.output().unwrap();
 //!     let string_output = String::from_utf8_lossy(&output.stdout);
 //!
-//!     if string_output == *"hello world" {
-//!         pass!()
-//!     } else {
-//!         fail!("expected 'hello world', got '{}'", string_output)
-//!     }
+//!     extel_assert!(
+//!         string_output == *"hello world",
+//!         "expected 'hello world', got '{}'",
+//!         string_output
+//!     )
 //! }
 //!
 //! #[parameters(1, 2, -2, 4)]
 //! fn param_test(x: i32) -> ExtelResult {
-//!     if x >= 0 {
-//!         pass!()
-//!     } else {
-//!         fail!("{} < 0", x)
-//!     }
+//!     extel_assert!(x > 0, "{} <= 0", x)
 //! }
 //!
 //! fn main() {

--- a/extel_parameterized/src/lib.rs
+++ b/extel_parameterized/src/lib.rs
@@ -9,8 +9,8 @@
 //!
 //! fn single_test() -> ExtelResult {
 //!     let mut my_cmd = cmd!("echo -n \"hello world\"");
-//!     let output = my_cmd.output().unwrap();
-//!     let string_output = String::from_utf8_lossy(&output.stdout);
+//!     let output = my_cmd.output()?;
+//!     let string_output = String::from_utf8(output.stdout)?;
 //!
 //!     extel_assert!(
 //!         string_output == *"hello world",

--- a/extel_parameterized/tests/parameterized.rs
+++ b/extel_parameterized/tests/parameterized.rs
@@ -1,41 +1,31 @@
-use extel::{fail, pass, ExtelResult, TestResultType, TestStatus};
+use extel::{prelude::*, TestResultType, TestStatus};
 use extel_parameterized::parameters;
 
 #[parameters((1, 1), (2, 3))]
 fn check_sum_into_two(sum: (i32, i32)) -> ExtelResult {
     const EXPECTED: i32 = 2;
-
     let (a, b) = sum;
-    match a + b {
-        EXPECTED => pass!(),
-        _ => fail!("invalid sum: expected {}, got {}", EXPECTED, a + b),
-    }
+    extel_assert!(
+        a + b == EXPECTED,
+        "invalid sum: expected {}, got {}",
+        EXPECTED,
+        a + b
+    )
 }
 
 #[parameters(vec![], vec![1])]
 fn check_vec(x: Vec<usize>) -> ExtelResult {
-    match x.is_empty() {
-        true => fail!("input is empty"),
-        false => pass!(),
-    }
+    extel_assert!(!x.is_empty(), "input is empty")
 }
 
 #[parameters(1, 2, -1)]
 pub fn check_pub_fn(x: i32) -> ExtelResult {
-    if x > 0 {
-        pass!()
-    } else {
-        fail!("x less than 0")
-    }
+    extel_assert!(x >= 0, "x less than 0")
 }
 
 #[parameters(1, 2, -1)]
 pub(crate) fn check_pub_crate_fn(x: i32) -> ExtelResult {
-    if x > 0 {
-        pass!()
-    } else {
-        fail!("x less than 0")
-    }
+    extel_assert!(x >= 0, "x less than 0")
 }
 
 mod super_test {
@@ -43,11 +33,7 @@ mod super_test {
 
     #[parameters(1, 2, -1)]
     pub(super) fn check_pub_super_fn(x: i32) -> ExtelResult {
-        if x > 0 {
-            pass!()
-        } else {
-            fail!("x less than 0")
-        }
+        extel_assert!(x >= 0, "x less than 0")
     }
 }
 

--- a/extel_parameterized/tests/parameterized.rs
+++ b/extel_parameterized/tests/parameterized.rs
@@ -1,4 +1,4 @@
-use extel::{prelude::*, TestResultType, TestStatus};
+use extel::{errors::Error as XE, prelude::*};
 use extel_parameterized::parameters;
 
 #[parameters((1, 1), (2, 3))]
@@ -50,71 +50,46 @@ mod super_test {
 
 #[test]
 fn parameters_tuples() {
-    assert_eq!(
-        check_sum_into_two().get_test_result(),
-        TestResultType::Parameterized(vec![
-            TestStatus::Success,
-            TestStatus::Fail("invalid sum: expected 2, got 5".to_string())
-        ])
-    );
+    assert!(matches!(
+        &check_sum_into_two()[..],
+        [Ok(_), Err(XE::TestFailed(_))]
+    ));
 }
 
 #[test]
 fn parameters_vec() {
-    assert_eq!(
-        check_vec().get_test_result(),
-        TestResultType::Parameterized(vec![
-            TestStatus::Fail("input is empty".to_string()),
-            TestStatus::Success
-        ])
-    );
+    assert!(matches!(&check_vec()[..], [Err(XE::TestFailed(_)), Ok(_)]));
 }
 
 #[test]
 fn parameters_pub() {
-    assert_eq!(
-        check_pub_fn().get_test_result(),
-        TestResultType::Parameterized(vec![
-            TestStatus::Success,
-            TestStatus::Success,
-            TestStatus::Fail("x less than 0".to_string())
-        ])
-    )
+    assert!(matches!(
+        &check_pub_fn()[..],
+        [Ok(_), Ok(_), Err(XE::TestFailed(_))]
+    ));
 }
 
 #[test]
 fn parameters_pub_crate() {
-    assert_eq!(
-        check_pub_crate_fn().get_test_result(),
-        TestResultType::Parameterized(vec![
-            TestStatus::Success,
-            TestStatus::Success,
-            TestStatus::Fail("x less than 0".to_string())
-        ])
-    )
+    assert!(matches!(
+        &check_pub_crate_fn()[..],
+        [Ok(_), Ok(_), Err(XE::TestFailed(_))]
+    ));
 }
 
 #[test]
 fn parameters_pub_super() {
     use super_test::*;
-    assert_eq!(
-        check_pub_super_fn().get_test_result(),
-        TestResultType::Parameterized(vec![
-            TestStatus::Success,
-            TestStatus::Success,
-            TestStatus::Fail("x less than 0".to_string())
-        ])
-    )
+    assert!(matches!(
+        &check_pub_super_fn()[..],
+        [Ok(_), Ok(_), Err(XE::TestFailed(_))]
+    ));
 }
 
 #[test]
 fn doc_comment() {
-    assert_eq!(
-        doc_comment_fn().get_test_result(),
-        TestResultType::Parameterized(vec![
-            TestStatus::Success,
-            TestStatus::Success,
-            TestStatus::Fail("x less than 0".to_string())
-        ])
-    )
+    assert!(matches!(
+        &doc_comment_fn()[..],
+        [Ok(_), Ok(_), Err(XE::TestFailed(_))]
+    ));
 }

--- a/extel_parameterized/tests/parameterized.rs
+++ b/extel_parameterized/tests/parameterized.rs
@@ -28,6 +28,17 @@ pub(crate) fn check_pub_crate_fn(x: i32) -> ExtelResult {
     extel_assert!(x >= 0, "x less than 0")
 }
 
+#[parameters(1, 2, -1)]
+/// This is a doc comment.
+fn doc_comment_fn(x: i32) -> ExtelResult {
+    #[parameters(1)]
+    fn y(x: i32) -> ExtelResult {
+        pass!()
+    }
+
+    extel_assert!(x >= 0, "x less than 0")
+}
+
 mod super_test {
     use super::*;
 
@@ -88,6 +99,18 @@ fn parameters_pub_super() {
     use super_test::*;
     assert_eq!(
         check_pub_super_fn().get_test_result(),
+        TestResultType::Parameterized(vec![
+            TestStatus::Success,
+            TestStatus::Success,
+            TestStatus::Fail("x less than 0".to_string())
+        ])
+    )
+}
+
+#[test]
+fn doc_comment() {
+    assert_eq!(
+        doc_comment_fn().get_test_result(),
         TestResultType::Parameterized(vec![
             TestStatus::Success,
             TestStatus::Success,


### PR DESCRIPTION
Add various QoL macros and features. Update documentation to reflect v0.1.3 and new changes. Fix bug where using `#[parameters(...)]` with doc comments caused compiler errors.